### PR TITLE
Route change anim

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2454,19 +2454,6 @@
         "html-tags": "^2.0.0",
         "react": ">=16.0.0",
         "styled-system": ">=1.1 || >=2.0"
-      },
-      "dependencies": {
-        "react": {
-          "version": "16.4.0",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.4.0.tgz",
-          "integrity": "sha512-K0UrkLXSAekf5nJu89obKUM7o2vc6MMN9LYoKnCa+c+8MJRAT120xzPLENcWSRc7GYKIg0LlgJRDorrufdglQQ==",
-          "requires": {
-            "fbjs": "^0.8.16",
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.0"
-          }
-        }
       }
     },
     "cli-boxes": {
@@ -14396,13 +14383,22 @@
       "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "system-components": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/system-components/-/system-components-2.0.4.tgz",
-      "integrity": "sha512-R2AGSpZjsa1P1S8X6aONzY49Y74d94KEzl/Q8z/zcch/8bKJFcBm7vLnPUtxypu8AaenvdG+/CtT6zv/fEYkpA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/system-components/-/system-components-2.2.2.tgz",
+      "integrity": "sha512-FgfspCQr98r1uBsXkHzJzW8/lDRa116Hib5SDXxSSHcx6R0q2gGeQF/CFtWVQNdKDynbfetoEukgPlR56QSHnA==",
       "requires": {
-        "clean-tag": "^1.0.3",
-        "styled-components": ">=3.0.0",
-        "styled-system": ">=2.0.1"
+        "clean-tag": "^1.0.4",
+        "styled-system": "^2.3.1"
+      },
+      "dependencies": {
+        "styled-system": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/styled-system/-/styled-system-2.3.2.tgz",
+          "integrity": "sha512-9B2t6nQm8jLBZejlWcCxSHCsAElGiEwcn+rQmvvpgJH/UyVI89wkiPSMSodMLwbMEov5Rx86cIEmXc3nJaJRuw==",
+          "requires": {
+            "prop-types": "^15.6.0"
+          }
+        }
       }
     },
     "systemjs": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "styled-components": "^3.3.2",
     "styled-css-grid": "^0.11.0",
     "styled-system": "^2.2.5",
-    "system-components": "^2.0.3"
+    "system-components": "^2.2.2"
   },
   "keywords": [
     "gatsby"

--- a/src/components/common/layout/Navigation.js
+++ b/src/components/common/layout/Navigation.js
@@ -106,7 +106,7 @@ class Navigation extends Component {
         onEnter={this.onEnter}
         onExit={this.onExit}
       >
-        {state => (
+        {() => (
           <div ref={el => (this.wrapper = el)} style={{ opacity: 1 }}>
             <NavWrapper color="black" bg="salmon">
               <Container

--- a/src/components/layout/AnimatedScreen.js
+++ b/src/components/layout/AnimatedScreen.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import { TimelineLite } from 'gsap';
+import { Box } from 'components';
+import { absolute } from 'utils/mixins';
+import { TransitionGroup, Transition } from 'react-transition-group';
+import withRouter from 'react-router/withRouter';
+
+const animationDuration = 600;
+const tweenDuration = animationDuration / 3000 * 2;
+
+const AnimationComponentWrapper = Box.extend`
+  ${absolute({ top: 0, bottom: 0, left: 0, right: 0 })};
+  z-index: 999;
+  transform: translateX(-100%);
+`;
+
+class AnimationComponent extends React.Component {
+  wrapper = React.createRef();
+
+  animate = () => {
+    const wrapper = this.wrapper.current;
+
+    this.animation = new TimelineLite();
+    this.animation
+      .set(wrapper, { x: '-100%' })
+      .to(wrapper, tweenDuration, { x: '0%' })
+      .to(wrapper, tweenDuration, { x: '-100%' }, `+=${tweenDuration}`)
+      .set(wrapper, { x: '-100%' });
+    this.animation.play();
+  };
+
+  render() {
+    return <AnimationComponentWrapper innerRef={this.wrapper} bg={'sea'} />;
+  }
+}
+
+class ScreenWrapper extends React.Component {
+  shouldComponentUpdate() {
+    // Do not update previous screen in order to keep the content visible while transitionning to new screen
+    return this.props.location.pathname === window.location.pathname;
+  }
+
+  render() {
+    const { state, render } = this.props;
+    return render(
+      state === 'entering'
+        ? {
+            style: {
+              display: 'none',
+            },
+          }
+        : {}
+    );
+  }
+}
+
+class _AnimatedScreen extends React.Component {
+  animationComponent = React.createRef();
+
+  onEntering = () => {
+    this.animationComponent.current.animate();
+  };
+
+  render() {
+    const { render, location } = this.props;
+    return (
+      <React.Fragment>
+        <AnimationComponent ref={this.animationComponent} />
+        <TransitionGroup component={null}>
+          <Transition
+            key={location.pathname}
+            timeout={animationDuration}
+            onEntering={this.onEntering}
+          >
+            {state => (
+              <ScreenWrapper
+                state={state}
+                location={location}
+                render={render}
+              />
+            )}
+          </Transition>
+        </TransitionGroup>
+      </React.Fragment>
+    );
+  }
+}
+
+export const AnimatedScreen = withRouter(_AnimatedScreen);

--- a/src/components/layout/ContaCta.js
+++ b/src/components/layout/ContaCta.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Button, CenterSection, Heading, Paragraph } from 'components';
+import { navigateTo } from 'gatsby-link';
 
 const ContaCta = () => (
   <CenterSection height="400px">

--- a/src/components/layout/Navigation.js
+++ b/src/components/layout/Navigation.js
@@ -83,7 +83,6 @@ class Navigation extends Component {
         opacity: 0,
         skewX: '-20deg',
         ease: Elastic.easeOut.config(0.25, 1),
-        onComplete: () => console.log('done'),
       },
       0.15
     );

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -1,12 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withRouter from 'react-router-dom/withRouter';
-import { TransitionGroup, Transition } from 'react-transition-group';
-import { TimelineLite } from 'gsap';
 import { injectGlobal, ThemeProvider } from 'styled-components';
 import { Toggle } from 'react-powerplug';
 import theme from 'utils/theme';
 import { Header, Footer, Navigation } from 'components';
+import { AnimatedScreen } from 'components/layout/AnimatedScreen';
 import { Box } from 'components';
 import { getFontFace } from 'utils/mixins';
 
@@ -25,64 +23,6 @@ injectGlobal`
   }
 `;
 
-class AnimatedScreen extends React.Component {
-  wrapper = React.createRef();
-
-  animate = () => {
-    const wrapper = this.wrapper.current;
-
-    this.animation = new TimelineLite();
-    this.animation
-      .set(wrapper, { x: '-100%' })
-      .to(wrapper, 0.4, { x: '0%' })
-      .to(wrapper, 0.4, { x: '-100%' }, '+=0.4')
-      .set(wrapper, { x: '-100%' });
-    this.animation.play();
-  };
-
-  render() {
-    return (
-      <Box
-        innerRef={this.wrapper}
-        bg={'sea'}
-        style={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          right: 0,
-          bottom: 0,
-          zIndex: 1000,
-          transform: 'translateX(-100%)',
-        }}
-      />
-    );
-  }
-}
-
-class ViewWrapper extends React.Component {
-  shouldComponentUpdate() {
-    // Do not update previous screen in order to keep the content visible while transitionning to new screen
-    return this.props.location.pathname === window.location.pathname;
-  }
-
-  render() {
-    const { state, children } = this.props;
-    return (
-      <Box
-        bg="gray.light"
-        pt={120}
-        style={{
-          position: 'absolute', // absolute is required because 2 screens can be on top of each other during the transition
-          width: '100%',
-          opacity: state === 'entering' ? 0 : 1,
-        }}
-      >
-        {children}
-      </Box>
-    );
-  }
-}
-
 const MainWrapper = Box.extend`
   height: ${props => (props.overflowHidden ? '100vh' : 'auto')};
   overflow-y: ${props => (props.overflowHidden ? 'hidden' : 'visible')};
@@ -96,29 +36,22 @@ class Layout extends React.Component {
   };
 
   render() {
-    const { children, location, data } = this.props;
+    const { children } = this.props;
     return (
       <ThemeProvider theme={theme}>
         <Toggle initial={false}>
           {({ on, toggle, set }) => (
-            <MainWrapper overflowHidden={on} p={0}>
-              <AnimatedScreen ref={this.animatedScreen} />
-              <TransitionGroup component={null}>
-                <Transition
-                  key={location.pathname}
-                  timeout={600}
-                  onEntering={this.onEntering}
-                >
-                  {state => (
-                    <ViewWrapper state={state} location={location}>
-                      <Header onToggleMenu={toggle} isMenuOpened={on} />
-                      <Box pb={6}>{children()}</Box>
-                      <Footer />
-                      <Navigation isOpened={on} onClose={() => set(false)} />
-                    </ViewWrapper>
-                  )}
-                </Transition>
-              </TransitionGroup>
+            <MainWrapper overflowHidden={on} p={0} bg="gray.light" pt={120}>
+              <Header onToggleMenu={toggle} isMenuOpened={on} />
+              <AnimatedScreen
+                render={props => (
+                  <Box pb={6} {...props}>
+                    {children()}
+                  </Box>
+                )}
+              />
+              <Footer />
+              <Navigation isOpened={on} onClose={() => set(false)} />
             </MainWrapper>
           )}
         </Toggle>
@@ -131,7 +64,7 @@ Layout.propTypes = {
   children: PropTypes.func,
 };
 
-export default withRouter(Layout);
+export default Layout;
 
 export const query = graphql`
   query SiteTitleQuery {

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -103,7 +103,7 @@ class Layout extends React.Component {
           {({ on, toggle, set }) => (
             <MainWrapper overflowHidden={on} p={0}>
               <AnimatedScreen ref={this.animatedScreen} />
-              <TransitionGroup>
+              <TransitionGroup component={null}>
                 <Transition
                   key={location.pathname}
                   timeout={600}

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -69,9 +69,11 @@ class ViewWrapper extends React.Component {
     const { state, children } = this.props;
     return (
       <Box
+        bg="gray.light"
         pt={120}
         style={{
           position: 'absolute', // absolute is required because 2 screens can be on top of each other during the transition
+          width: '100%',
           opacity: state === 'entering' ? 0 : 1,
         }}
       >
@@ -99,7 +101,7 @@ class Layout extends React.Component {
       <ThemeProvider theme={theme}>
         <Toggle initial={false}>
           {({ on, toggle, set }) => (
-            <MainWrapper overflowHidden={on} p={0} bg="gray.light">
+            <MainWrapper overflowHidden={on} p={0}>
               <AnimatedScreen ref={this.animatedScreen} />
               <TransitionGroup>
                 <Transition

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -26,10 +26,8 @@ injectGlobal`
 `;
 
 class AnimatedScreen extends React.Component {
-  wrapper = React.createRef();
-
   animate = () => {
-    const wrapper = this.wrapper.current;
+    const wrapper = this.wrapper;
 
     this.animation = new TimelineLite();
     this.animation
@@ -43,7 +41,7 @@ class AnimatedScreen extends React.Component {
   render() {
     return (
       <Box
-        innerRef={this.wrapper}
+        innerRef={el => (this.wrapper = el)}
         bg={'sea'}
         style={{
           position: 'absolute',

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -28,37 +28,26 @@ const MainWrapper = Box.extend`
   overflow-y: ${props => (props.overflowHidden ? 'hidden' : 'visible')};
 `;
 
-class Layout extends React.Component {
-  animatedScreen = React.createRef();
-
-  onEntering = () => {
-    this.animatedScreen.current.animate();
-  };
-
-  render() {
-    const { children } = this.props;
-    return (
-      <ThemeProvider theme={theme}>
-        <Toggle initial={false}>
-          {({ on, toggle, set }) => (
-            <MainWrapper overflowHidden={on} p={0} bg="gray.light" pt={120}>
-              <Header onToggleMenu={toggle} isMenuOpened={on} />
-              <AnimatedScreen
-                render={props => (
-                  <Box pb={6} {...props}>
-                    {children()}
-                  </Box>
-                )}
-              />
-              <Footer />
-              <Navigation isOpened={on} onClose={() => set(false)} />
-            </MainWrapper>
-          )}
-        </Toggle>
-      </ThemeProvider>
-    );
-  }
-}
+const Layout = ({ children, data }) => (
+  <ThemeProvider theme={theme}>
+    <Toggle initial={false}>
+      {({ on, toggle, set }) => (
+        <MainWrapper overflowHidden={on} p={0} pt="120px" bg="gray.light">
+          <Header onToggleMenu={toggle} isMenuOpened={on} />
+          <AnimatedScreen
+            render={props => (
+              <Box pb={6} {...props}>
+                {children()}
+              </Box>
+            )}
+          />
+          <Footer />
+          <Navigation isOpened={on} onClose={() => set(false)} />
+        </MainWrapper>
+      )}
+    </Toggle>
+  </ThemeProvider>
+);
 
 Layout.propTypes = {
   children: PropTypes.func,

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -26,8 +26,10 @@ injectGlobal`
 `;
 
 class AnimatedScreen extends React.Component {
+  wrapper = React.createRef();
+
   animate = () => {
-    const wrapper = this.wrapper;
+    const wrapper = this.wrapper.current;
 
     this.animation = new TimelineLite();
     this.animation
@@ -41,7 +43,7 @@ class AnimatedScreen extends React.Component {
   render() {
     return (
       <Box
-        innerRef={el => (this.wrapper = el)}
+        innerRef={this.wrapper}
         bg={'sea'}
         style={{
           position: 'absolute',

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -1,5 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import withRouter from 'react-router-dom/withRouter';
+import { TransitionGroup, Transition } from 'react-transition-group';
+import { TimelineLite } from 'gsap';
 import { injectGlobal, ThemeProvider } from 'styled-components';
 import { Toggle } from 'react-powerplug';
 import theme from 'utils/theme';
@@ -22,31 +25,111 @@ injectGlobal`
   }
 `;
 
+class AnimatedScreen extends React.Component {
+  wrapper = React.createRef();
+
+  animate = () => {
+    const wrapper = this.wrapper.current;
+
+    this.animation = new TimelineLite();
+    this.animation
+      .set(wrapper, { x: '-100%' })
+      .to(wrapper, 0.4, { x: '0%' })
+      .to(wrapper, 0.4, { x: '-100%' }, '+=0.4')
+      .set(wrapper, { x: '-100%' });
+    this.animation.play();
+  };
+
+  render() {
+    return (
+      <Box
+        innerRef={this.wrapper}
+        bg={'sea'}
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          zIndex: 1000,
+          transform: 'translateX(-100%)',
+        }}
+      />
+    );
+  }
+}
+
+class ViewWrapper extends React.Component {
+  shouldComponentUpdate() {
+    // Do not update previous screen in order to keep the content visible while transitionning to new screen
+    return this.props.location.pathname === window.location.pathname;
+  }
+
+  render() {
+    const { state, children } = this.props;
+    return (
+      <Box
+        pt={120}
+        style={{
+          position: 'absolute', // absolute is required because 2 screens can be on top of each other during the transition
+          opacity: state === 'entering' ? 0 : 1,
+        }}
+      >
+        {children}
+      </Box>
+    );
+  }
+}
+
 const MainWrapper = Box.extend`
   height: ${props => (props.overflowHidden ? '100vh' : 'auto')};
   overflow-y: ${props => (props.overflowHidden ? 'hidden' : 'visible')};
 `;
 
-const Layout = ({ children, data }) => (
-  <ThemeProvider theme={theme}>
-    <Toggle initial={false}>
-      {({ on, toggle, set }) => (
-        <MainWrapper overflowHidden={on} p={0} pt="120px" bg="gray.light">
-          <Header onToggleMenu={toggle} isMenuOpened={on} />
-          <Box pb={6}> {children()} </Box>
-          <Footer />
-          <Navigation isOpened={on} onClose={() => set(false)} />
-        </MainWrapper>
-      )}
-    </Toggle>
-  </ThemeProvider>
-);
+class Layout extends React.Component {
+  animatedScreen = React.createRef();
+
+  onEntering = () => {
+    this.animatedScreen.current.animate();
+  };
+
+  render() {
+    const { children, location, data } = this.props;
+    return (
+      <ThemeProvider theme={theme}>
+        <Toggle initial={false}>
+          {({ on, toggle, set }) => (
+            <MainWrapper overflowHidden={on} p={0} bg="gray.light">
+              <AnimatedScreen ref={this.animatedScreen} />
+              <TransitionGroup>
+                <Transition
+                  key={location.pathname}
+                  timeout={600}
+                  onEntering={this.onEntering}
+                >
+                  {state => (
+                    <ViewWrapper state={state} location={location}>
+                      <Header onToggleMenu={toggle} isMenuOpened={on} />
+                      <Box pb={6}>{children()}</Box>
+                      <Footer />
+                      <Navigation isOpened={on} onClose={() => set(false)} />
+                    </ViewWrapper>
+                  )}
+                </Transition>
+              </TransitionGroup>
+            </MainWrapper>
+          )}
+        </Toggle>
+      </ThemeProvider>
+    );
+  }
+}
 
 Layout.propTypes = {
   children: PropTypes.func,
 };
 
-export default Layout;
+export default withRouter(Layout);
 
 export const query = graphql`
   query SiteTitleQuery {


### PR DESCRIPTION
Voià un petit test de transition de page avec gsap et transitiongroup.  
Je ne savais pas trop comment gérer les position absolute avec Box donc j'ai mis des balises style pour le moment.  

Pour la petite explication de comment ça marche (et comment je l'ai compris) :  

Il y a un TransitionGroup suivi d'un Transition avec une key correspondante à la route actuelle.   

Lorsqu'une nouvelle route est demandée, le précédent Transition passe au statut "exiting" et reste présent dans le DOM le temps que `timeout` ait expiré.   
Pour que l'ancien contenu ne disparaisse pas, il est encapsulé dans un composant avec shouldComponentUpdate qui répond false dans ce cas.   

Le nouveau Transition avec la nouvelle key apparaît aussitôt dans le DOM au dessus du précédent.  
Il faut donc mettre ces Transition en position absolute pour qu'il soit l'un sur l'autre et mettre une opacity à 0 sur la nouvelle Transition.  

Lorsque que le `timeout` expire, le précédent Transition est retiré du DOM et le nouveau prend une opacity de 1.  Ce switch est transparent car il se produit au milieu de l'animation lorsque l'écran est masqué.